### PR TITLE
From notes in WebSphereMqClient/readme.md - this is a sample unit tes…

### DIFF
--- a/src/WebSphereMqClientTest/MessageQueue.cs
+++ b/src/WebSphereMqClientTest/MessageQueue.cs
@@ -1,0 +1,178 @@
+﻿using IBM.WMQ;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WebSphereMqClientTest
+{
+    public class MessageQueue : IDisposable
+    {
+        private readonly QueueOptions _queueOptions;
+
+        private MQQueueManager _queueManager;
+        private MQQueue _queue;
+
+        public MessageQueue(QueueOptions queueOptions)
+        {
+            _queueOptions = queueOptions;
+        }
+
+        public bool IsAttached { get; private set; }
+
+        public string QueueName
+        {
+            get { return _queueOptions.QueueName; }
+        }
+
+        public void Attach()
+        {
+            var properties = new Hashtable
+            {
+                {MQC.TRANSPORT_PROPERTY, MQC.TRANSPORT_MQSERIES_MANAGED},
+                {MQC.HOST_NAME_PROPERTY, _queueOptions.HostName},
+                {MQC.PORT_PROPERTY, _queueOptions.Port},
+                {MQC.CHANNEL_PROPERTY, _queueOptions.Channel},
+            };
+
+            try
+            {
+                Console.WriteLine("Queue {0} is connecting to queue manager {1}", QueueName, _queueOptions.QueueManagerName);
+                _queueManager = new MQQueueManager(_queueOptions.QueueManagerName, properties);
+
+                int openOptions = MQC.MQOO_FAIL_IF_QUIESCING;
+                if ((_queueOptions.AccessLevel & QueueAccess.Get) == QueueAccess.Get)
+                {
+                    openOptions += MQC.MQOO_INPUT_AS_Q_DEF;
+                }
+                if ((_queueOptions.AccessLevel & QueueAccess.Put) == QueueAccess.Put)
+                {
+                    openOptions += MQC.MQOO_OUTPUT;
+                }
+                if ((_queueOptions.AccessLevel & QueueAccess.Browse) == QueueAccess.Browse)
+                {
+                    openOptions += MQC.MQOO_INQUIRE;
+                }
+                Console.WriteLine("Accessing queue {0} with options {1:G}...", QueueName, _queueOptions.AccessLevel);
+
+                _queue = _queueManager.AccessQueue(_queueOptions.QueueName, openOptions);
+
+                Console.WriteLine("Queue {0} is successfully attached.", QueueName);
+
+                // reset point for transactional support
+                IsAttached = true;
+            }
+
+            catch (MQException)
+            {
+                // wrap exception
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (IsAttached)
+            {
+                Detach();
+            }
+        }
+
+        public void Detach()
+        {
+            Console.WriteLine("Detaching from queue {0}...", QueueName);
+
+            // transactions: add wait 
+
+            // transactions: rollback wait check
+
+            ActIfNotNull(_queue, () => _queue.Close(), "close");
+            ActIfNotNull(_queueManager, () => _queueManager.Disconnect(), "disconnect");
+
+            _queue = null;
+            _queueManager = null;
+
+            IsAttached = false;
+        }
+        
+        private void ActIfNotNull<T>(T entity, Action action, string operation) where T : class
+        {
+            try
+            {
+                if (entity != null)
+                {
+                    action();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error performing operation '{0}' for queue {1}...", operation, QueueName, ex);
+            }
+        }
+        
+        public void PutMessageBlock(string messageContent)
+        {
+            var putMessageOptions = new MQPutMessageOptions();
+            // add for transactions
+            // putMessageOptions.Options += MQC.MQPMO_SYNCPOINT;
+            PutMessage(messageContent, putMessageOptions);
+
+            // commit transaction
+        }
+
+        private void PutMessage(string messageContent, MQPutMessageOptions putMessageOptions)
+        {
+            try
+            {
+                var message = new MQMessage();
+                message.Write(Encoding.UTF8.GetBytes(messageContent));
+                _queue.Put(message, putMessageOptions);
+            }
+
+            catch (MQException)
+            {
+                // wrap exception
+                throw;
+            }
+        }
+
+        public string GetMessageBlock()
+        {
+            var getMessageOptions = new MQGetMessageOptions();
+            // transactions: 
+            // getMessageOptions.Options += MQC.MQGMO_SYNCPOINT;
+            getMessageOptions.Options += MQC.MQGMO_WAIT;
+            getMessageOptions.WaitInterval = _queueOptions.WaitMilliseconds;
+            return GetMessage(getMessageOptions);
+        }
+
+        private string GetMessage(MQGetMessageOptions getMessageOptions)
+        {
+            // transactions: add wait
+
+            // transactions: add rollback wait check
+
+            try
+            {
+                // if transaction exists, add transaction complete handler
+                var message = new MQMessage();
+                _queue.Get(message, getMessageOptions);
+                var result = message.ReadString(message.MessageLength);
+                message.ClearMessage();
+
+                return result;
+            }
+
+            catch (MQException mqe)
+            {
+                // queue empty
+                if (mqe.ReasonCode == 2033)
+                {
+                    return null;
+                }
+                // wrap exception
+                throw;
+            }
+        }
+    }
+}

--- a/src/WebSphereMqClientTest/MessageQueueTest.cs
+++ b/src/WebSphereMqClientTest/MessageQueueTest.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Configuration;
+
+namespace WebSphereMqClientTest
+{
+    [TestClass]
+    public class MessageQueueTest
+    {
+        [TestMethod]
+        public void TestGetSet()
+        {
+            QueueOptions options = new QueueOptions();
+            options.AccessLevel = QueueAccess.Put | QueueAccess.Get;
+            int portNumber = 1414;
+            int.TryParse(ConfigurationManager.AppSettings["port"], out portNumber);
+            options.Port = portNumber;
+            options.HostName = ConfigurationManager.AppSettings["host"];
+            options.QueueManagerName = ConfigurationManager.AppSettings["manager"];
+            options.Channel = ConfigurationManager.AppSettings["channel"];
+            options.QueueName = ConfigurationManager.AppSettings["queue"];
+            options.WaitMilliseconds = 1000;
+
+            var message = Guid.NewGuid().ToString();
+            string response = null;
+            using (MessageQueue client = new MessageQueue(options))
+            {
+                client.Attach();
+                client.PutMessageBlock(message);
+                response = client.GetMessageBlock();
+            }
+            Assert.AreEqual(message, response);
+        }
+    }
+}

--- a/src/WebSphereMqClientTest/NuGet.Config
+++ b/src/WebSphereMqClientTest/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-packages" value="..\..\WebSphereMqClient\build" />
+  </packageSources>
+</configuration>

--- a/src/WebSphereMqClientTest/Properties/AssemblyInfo.cs
+++ b/src/WebSphereMqClientTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("WebSphereMqClientTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebSphereMqClientTest")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("a34389d6-384a-409e-ace1-c797d005657f")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/WebSphereMqClientTest/QueueAccess.cs
+++ b/src/WebSphereMqClientTest/QueueAccess.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebSphereMqClientTest
+{
+    [System.Flags]
+    public enum QueueAccess
+    {
+        None = 0,
+        /// <summary>
+        /// Get messages
+        /// </summary>
+        Get = 1,
+        /// <summary>
+        /// Put messages
+        /// </summary>
+        Put = 2,
+        /// <summary>
+        /// Know message queue length
+        /// </summary>
+        Browse = 4,
+    }
+}

--- a/src/WebSphereMqClientTest/QueueOptions.cs
+++ b/src/WebSphereMqClientTest/QueueOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WebSphereMqClientTest
+{
+    public class QueueOptions
+    {
+        public QueueAccess AccessLevel { get; internal set; }
+        public string Channel { get; internal set; }
+        public string HostName { get; internal set; }
+        public int Port { get; internal set; }
+        public string QueueManagerName { get; internal set; }
+        public string QueueName { get; internal set; }
+        public int WaitMilliseconds { get; internal set; }
+    }
+}

--- a/src/WebSphereMqClientTest/WebSphereMqClientTest.csproj
+++ b/src/WebSphereMqClientTest/WebSphereMqClientTest.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A34389D6-384A-409E-ACE1-C797D005657F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebSphereMqClientTest</RootNamespace>
+    <AssemblyName>WebSphereMqClientTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="amqmdnet, Version=8.0.0.8, Culture=neutral, PublicKeyToken=dd3cb1c9aae9ec97, processorArchitecture=MSIL">
+      <HintPath>packages\WebSphereMqClient.8.0.0.8\lib\net20\amqmdnet.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MessageQueue.cs" />
+    <Compile Include="MessageQueueTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueueAccess.cs" />
+    <Compile Include="QueueOptions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/src/WebSphereMqClientTest/WebSphereMqClientTest.sln
+++ b/src/WebSphereMqClientTest/WebSphereMqClientTest.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2002
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSphereMqClientTest", "WebSphereMqClientTest.csproj", "{A34389D6-384A-409E-ACE1-C797D005657F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A34389D6-384A-409E-ACE1-C797D005657F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A34389D6-384A-409E-ACE1-C797D005657F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A34389D6-384A-409E-ACE1-C797D005657F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A34389D6-384A-409E-ACE1-C797D005657F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {48D77573-E63D-4DB9-AA68-61541D66114F}
+	EndGlobalSection
+EndGlobal

--- a/src/WebSphereMqClientTest/app.config
+++ b/src/WebSphereMqClientTest/app.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="amqmdnet" publicKeyToken="dd3cb1c9aae9ec97" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.8" newVersion="8.0.0.8" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <appSettings>
+    <add key="host" value="localhost" />
+    <add key="port" value="1414" />
+    <add key="manager" value="TEST.MANAGER" />
+    <add key="channel" value="TEST.CH" />
+    <add key="queue" value="TEST1" />
+  </appSettings>
+</configuration>

--- a/src/WebSphereMqClientTest/build.cmd
+++ b/src/WebSphereMqClientTest/build.cmd
@@ -1,0 +1,3 @@
+nuget restore
+dotnet build
+dotnet test

--- a/src/WebSphereMqClientTest/packages.config
+++ b/src/WebSphereMqClientTest/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net45" />
+  <package id="WebSphereMqClient" version="8.0.0.8" targetFramework="net45" />
+</packages>

--- a/src/WebSphereMqClientTest/readme.md
+++ b/src/WebSphereMqClientTest/readme.md
@@ -1,0 +1,11 @@
+
+Download dotnet.exe tools `https://docs.microsoft.com/en-us/dotnet/core/tools/index?tabs=netcore2x` and install.
+
+Edit `app.config` modifying the appSetting <add> elements to suit your local MQ instance
+
+Run `..\..\WebSphereMqClient\build.cmd` to create local nuget package
+
+Run `build.cmd`
+- Requires nuget.exe in path
+
+The test inside MessageQueueTest.cs will connect to the host/channel/port/manager/queue, and place a message onto the queue, then read it off again.


### PR DESCRIPTION
Hello Dzmitry, 

I read in your readme.md file in the TODO was creating a sample application to call MQ.

I've stripped down a client I use to the bare-bones required for non-transactional get and put.
It only requires the IBM amqmdnet.dll, I've only tested it on MQ7.5 but should work just as well with MQ8.

It tests the nupkg file that the WebSphereMqClient/build.cmd creates, and runs a unit test.

If you would like to include it in your repository please feel free, or any feedback would be appreciated.

Thanks,
Clive